### PR TITLE
Changed Forecast Weather source to Tempest API

### DIFF
--- a/custom_components/smartweather/weather.py
+++ b/custom_components/smartweather/weather.py
@@ -14,7 +14,7 @@ import asyncio
 import aiohttp
 import async_timeout
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 import voluptuous as vol
 
 from requests.exceptions import ConnectionError as ConnectError
@@ -247,11 +247,16 @@ class TempestWeather(WeatherEntityExtended):
     def forecast(self):
         """Return the forecast."""        
         forecast_data = []
-        daily_forcasts = iter(self._data.forecast['daily'])
-        next(daily_forcasts) # Don't want forcast for today
+        #next(daily_forcasts) # Don't want forcast for today
+        today = datetime.now()
 
-        for entry in daily_forcasts:
-            # First, calculate data from hourly that's not summed up in the daily.
+        for entry in self._data.forecast['daily']:
+            # Skip over past forecasts - seems the API sometimes returns old forecasts
+            forecast_time = datetime.fromtimestamp(entry['day_start_local'])
+            if today > forecast_time:
+                continue
+
+            # Calculate data from hourly that's not summed up in the daily.
             precip = 0
             wind_avg = []
             wind_bearing = []


### PR DESCRIPTION
Quick updates to feed the data from the Tempest SmartWeather API, probably some clean-up needed. I tested this with my own weather station & HassOS 4.11. Note that I tested this with a *public* station. If your Tempest station is not public, either make it so or you would need to figure what is your API key to access it. 

Only need the following for the weather entity to work in configuration.yaml, the key is standard DEV key:
```
weather:
  - platform: smartweather
      
smartweather:
  station_id: <your station id here>
  api_key: 20c70eae-e62f-4d3b-b3a4-8586e90f3ac8
```

All the data is pulled from SmartWeatherCurrentData.update() and the weather.py module pulls it from hass.data[DATA_SMARTWEATHER].

I suspect there is still some issues with unit types & conversions. 