### PR TITLE
Have both daily and hourly forecast for same station

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### V2.2.2
+
+*Released January 29th, 2021*
+
+* `FIXED`: Issue #52, where 0 values were reported if there was a glitch in the retrival of data from WeatherFlow. Certain sensors, like the Pressure Sensors, will not update, until a valid numbers is received.
+* `ADDED`: There is now the possibility to add the same Station ID twice, with a different Forecast Type. So if you want to both have the Daily and Hourly Forecast data, then add the station again, but this time select the Forecast Type you did not have setup already. I recommend that on the second install, you de-select the check-box `Install individual sensors` so that you don't get the sensors double.
+
 ### V2.2.1
 
 *Released January 9th, 2021*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 *Released January 29th, 2021*
 
 * `FIXED`: Issue #52, where 0 values were reported if there was a glitch in the retrival of data from WeatherFlow. Certain sensors, like the Pressure Sensors, will not update, until a valid numbers is received.
-* `ADDED`: There is now the possibility to add the same Station ID twice, with a different Forecast Type. So if you want to both have the Daily and Hourly Forecast data, then add the station again, but this time select the Forecast Type you did not have setup already. I recommend that on the second install, you de-select the check-box `Install individual sensors` so that you don't get the sensors double.
+* `ADDED`: Issue #51 and #53. There is now the possibility to add the same Station ID twice, with a different Forecast Type. So if you want to both have the Daily and Hourly Forecast data, then add the station again, but this time select the Forecast Type you did not have setup already. I recommend that on the second install, you de-select the check-box `Install individual sensors` so that you don't get the sensors double.
 
 ### V2.2.1
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The WeatherFlow REST API requires a Token. If you own a WeatherFlow station you 
 
 WeatherFlow is releasing a new Authorization flow, so in the future you will have to obtain your own personal key, or use Oauth2 to retrieve data. The *developer key* will continue to operate through the end of 2020, but after that, you will need to obtain your own key. You can read [more here](https://weatherflow.github.io/Tempest/api/oauth.html) on how to obtain your own key - please note Oauth2 is not currently implemented in this integration.
 
-Thanks to @jeroenterheerdt here is hint to how you get your personal Token: After you have your account, go to https://tempestwx.com/ and sign-in. Go to Settings and choose Data Authorizations (almost at the bottom). Create a personal access token and use that as API key.
+Thanks to @jeroenterheerdt here is how to you get your personal Token (API Key): After you have your account, go to https://tempestwx.com/ and sign-in. Go to Settings and choose Data Authorizations (almost at the bottom). Create a personal access token and use that as Token (API key).
 
 #### Station ID
 If you have your own Smart Weather Station, then you know your Station ID. If you don't have one, there are a lot of public stations available, and you can find one near you on [this link](https://smartweather.weatherflow.com/map). If you click on one of the stations on the map, you will see that the URL changes, locate the number right after */map/* - this is the Station ID

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ The WeatherFlow REST API requires a Token. If you own a WeatherFlow station you 
 
 WeatherFlow is releasing a new Authorization flow, so in the future you will have to obtain your own personal key, or use Oauth2 to retrieve data. The *developer key* will continue to operate through the end of 2020, but after that, you will need to obtain your own key. You can read [more here](https://weatherflow.github.io/Tempest/api/oauth.html) on how to obtain your own key - please note Oauth2 is not currently implemented in this integration.
 
+Thanks to @jeroenterheerdt here is hint to how you get your personal Token: After you have your account, go to https://tempestwx.com/ and sign-in. Go to Settings and choose Data Authorizations (almost at the bottom). Create a personal access token and use that as API key.
+
 #### Station ID
 If you have your own Smart Weather Station, then you know your Station ID. If you don't have one, there are a lot of public stations available, and you can find one near you on [this link](https://smartweather.weatherflow.com/map). If you click on one of the stations on the map, you will see that the URL changes, locate the number right after */map/* - this is the Station ID
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ During installation you will have the option of selecting if you want to:
 
 These settings can also be changed after you add the Integration, by using the *Options* link on the Integration widget.
 
+You can configure more than 1 instance of the Integration by either using a different Station ID, og by using the same Station ID, but then a different Forecast Type (Daily / Hourly). If you select the last option de-select the check-box `Install individual sensors` as this will only create the same sensors two times.
+
 ### Token for SmartWeather
 The WeatherFlow REST API requires a Token. If you own a WeatherFlow station you can [login with your account](https://tempestwx.com/settings/tokens) and create the token.
 

--- a/custom_components/smartweather/__init__.py
+++ b/custom_components/smartweather/__init__.py
@@ -184,13 +184,14 @@ async def _async_get_or_create_smartweather_device_in_registry(
     hass: HomeAssistantType, entry: ConfigEntry, svr
 ) -> None:
     device_registry = await dr.async_get_registry(hass)
-    device_key = f"{entry.data[CONF_STATION_ID]}"
+    device_key = f"{entry.data[CONF_STATION_ID]}_{entry.data[CONF_FORECAST_TYPE]}"
+    _LOGGER.debug("DEVICE KEY: %s", device_key)
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, device_key)},
         identifiers={(DOMAIN, device_key)},
         manufacturer=DEFAULT_BRAND,
-        name=svr["station_name"],
+        name=f"{svr['station_name']} ({entry.data[CONF_FORECAST_TYPE].capitalize()})",
         model=svr["station_type"],
         sw_version=svr["firmware_revision"],
     )

--- a/custom_components/smartweather/config_flow.py
+++ b/custom_components/smartweather/config_flow.py
@@ -75,10 +75,6 @@ class SmartWeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             unique_id = await smartweather.get_station_name()
-            # unique_id = slugify(unique_id).capitalize()
-            # underscore_pos = unique_id.find("_")
-            # if underscore_pos > 0:
-            #     unique_id = unique_id.split("_")[0]
         except InvalidApiKey:
             errors["base"] = "api_error"
             return await self._show_setup_form(errors)
@@ -88,13 +84,16 @@ class SmartWeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         entries = self._async_current_entries()
         for entry in entries:
-            if entry.data[CONF_ID] == unique_id:
+            if (
+                f"{entry.data[CONF_ID]}"
+                == f"{unique_id}_{user_input[CONF_FORECAST_TYPE]}"
+            ):
                 return self.async_abort(reason="station_exists")
 
         return self.async_create_entry(
-            title=unique_id,
+            title=f"{unique_id} ({user_input[CONF_FORECAST_TYPE].capitalize()})",
             data={
-                CONF_ID: unique_id,
+                CONF_ID: f"{unique_id}_{user_input[CONF_FORECAST_TYPE]}",
                 CONF_API_KEY: user_input[CONF_API_KEY],
                 CONF_STATION_ID: user_input[CONF_STATION_ID],
                 CONF_FORECAST_TYPE: user_input[CONF_FORECAST_TYPE],

--- a/custom_components/smartweather/entity.py
+++ b/custom_components/smartweather/entity.py
@@ -6,6 +6,7 @@ from homeassistant.const import ATTR_ATTRIBUTION
 from .const import (
     DOMAIN,
     ATTR_SMARTWEATHER_STATION_ID,
+    CONF_FORECAST_TYPE,
     CONF_STATION_ID,
     DEFAULT_BRAND,
     DEFAULT_ATTRIBUTION,
@@ -30,7 +31,9 @@ class SmartWeatherEntity(Entity):
         self._entity = entity
         self._platform_serial = self.server["serial_number"]
         self._platform_id = server["station_type"]
-        self._device_key = f"{self.entries[CONF_STATION_ID]}"
+        self._device_key = (
+            f"{self.entries[CONF_STATION_ID]}_{self.entries[CONF_FORECAST_TYPE]}"
+        )
         if self._entity == DEVICE_TYPE_WEATHER:
             self._unique_id = self._device_key
         else:

--- a/custom_components/smartweather/sensor.py
+++ b/custom_components/smartweather/sensor.py
@@ -39,120 +39,203 @@ from .entity import SmartWeatherEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-# Sensor types are defined like: Name, Unit Type, icon, device class
+# Sensor types are defined like: Name, Unit Type, icon, device class, Ignore on 0 Value
 SENSOR_TYPES = {
     "air_temperature": [
         "Temperature",
         UNIT_TYPE_TEMP,
         "mdi:thermometer",
         DEVICE_CLASS_TEMPERATURE,
+        False,
     ],
     "air_density": [
         "Air Density",
         "kg/m3",
         "mdi:weight-kilogram",
         None,
+        False,
     ],
     "feels_like": [
         "Feels Like",
         UNIT_TYPE_TEMP,
         "mdi:thermometer",
         DEVICE_CLASS_TEMPERATURE,
+        False,
     ],
     "heat_index": [
         "Heat Index",
         UNIT_TYPE_TEMP,
         "mdi:thermometer",
         DEVICE_CLASS_TEMPERATURE,
+        False,
     ],
     "wind_chill": [
         "Wind Chill",
         UNIT_TYPE_TEMP,
         "mdi:thermometer",
         DEVICE_CLASS_TEMPERATURE,
+        False,
     ],
     "dew_point": [
         "Dewpoint",
         UNIT_TYPE_TEMP,
         "mdi:thermometer",
         DEVICE_CLASS_TEMPERATURE,
+        False,
     ],
-    "wind_avg": ["Wind Speed", UNIT_TYPE_WIND, "mdi:weather-windy", None],
-    "wind_bearing": ["Wind Bearing", "°", "mdi:compass-outline", None],
-    "wind_direction": ["Wind Direction", None, "mdi:compass-outline", None],
-    "wind_gust": ["Wind Gust", UNIT_TYPE_WIND, "mdi:weather-windy", None],
-    "precip_accum_local_day": ["Rain today", UNIT_TYPE_RAIN, "mdi:weather-rainy", None],
-    "precip_rate": ["Rain rate", UNIT_TYPE_RAIN, "mdi:weather-pouring", None],
+    "wind_avg": [
+        "Wind Speed",
+        UNIT_TYPE_WIND,
+        "mdi:weather-windy",
+        None,
+        False,
+    ],
+    "wind_bearing": [
+        "Wind Bearing",
+        "°",
+        "mdi:compass-outline",
+        None,
+        False,
+    ],
+    "wind_direction": [
+        "Wind Direction",
+        None,
+        "mdi:compass-outline",
+        None,
+        False,
+    ],
+    "wind_gust": [
+        "Wind Gust",
+        UNIT_TYPE_WIND,
+        "mdi:weather-windy",
+        None,
+        False,
+    ],
+    "precip_accum_local_day": [
+        "Rain today",
+        UNIT_TYPE_RAIN,
+        "mdi:weather-rainy",
+        None,
+        False,
+    ],
+    "precip_rate": [
+        "Rain rate",
+        UNIT_TYPE_RAIN,
+        "mdi:weather-pouring",
+        None,
+        False,
+    ],
     "precip_accum_last_1hr": [
         "Rain last hour",
         UNIT_TYPE_RAIN,
         "mdi:weather-rainy",
         None,
+        False,
     ],
     "precip_accum_local_yesterday": [
         "Rain yesterday",
         UNIT_TYPE_RAIN,
         "mdi:weather-rainy",
         None,
+        False,
     ],
-    "pressure_trend": ["Pressure Trend", None, "mdi:trending-up", None],
-    "relative_humidity": ["Humidity", "%", "mdi:water-percent", DEVICE_CLASS_HUMIDITY],
+    "pressure_trend": [
+        "Pressure Trend",
+        None,
+        "mdi:trending-up",
+        None,
+        False,
+    ],
+    "relative_humidity": [
+        "Humidity",
+        "%",
+        "mdi:water-percent",
+        DEVICE_CLASS_HUMIDITY,
+        True,
+    ],
     "station_pressure": [
         "Pressure",
         UNIT_TYPE_PRESSURE,
         "mdi:gauge",
         DEVICE_CLASS_PRESSURE,
+        True,
     ],
     "sea_level_pressure": [
         "Sea Level Pressure",
         UNIT_TYPE_PRESSURE,
         "mdi:gauge",
         DEVICE_CLASS_PRESSURE,
+        True,
     ],
-    "uv": ["UV", "UV", "mdi:weather-sunny", None],
-    "solar_radiation": ["Solar Radiation", "W/m2", "mdi:solar-power", None],
+    "uv": [
+        "UV",
+        "UV",
+        "mdi:weather-sunny",
+        None,
+        False,
+    ],
+    "solar_radiation": [
+        "Solar Radiation",
+        "W/m2",
+        "mdi:solar-power",
+        None,
+        False,
+    ],
     "brightness": [
         "Brightness",
         "Lx",
         "mdi:brightness-5",
         DEVICE_CLASS_ILLUMINANCE,
+        False,
     ],
-    "lightning_strike_count": ["Lightning Count", None, "mdi:weather-lightning", None],
+    "lightning_strike_count": [
+        "Lightning Count",
+        None,
+        "mdi:weather-lightning",
+        None,
+        False,
+    ],
     "lightning_strike_last_distance": [
         "Lightning Distance",
         UNIT_TYPE_DISTANCE,
         "mdi:weather-lightning",
         None,
+        False,
     ],
     "lightning_strike_last_time": [
         "Lightning Time",
         "",
         "mdi:clock-outline",
         None,
+        False,
     ],
     "lightning_strike_count_last_1hr": [
         "Lightning Last 1Hrs",
         "",
         "mdi:history",
         None,
+        False,
     ],
     "lightning_strike_count_last_3hr": [
         "Lightning Last 3Hrs",
         "",
         "mdi:history",
         None,
+        False,
     ],
     "precip_minutes_local_day": [
         "Rain minutes today",
         "min",
         "mdi:timer-outline",
         None,
+        False,
     ],
     "precip_minutes_local_yesterday": [
         "Rain minutes yesterday",
         "min",
         "mdi:timer-outline",
         None,
+        False,
     ],
 }
 
@@ -262,6 +345,8 @@ class SmartWeatherSensor(SmartWeatherEntity, Entity):
         else:
             value = getattr(self.coordinator.data[0], self._sensor, None)
             if not isinstance(value, str) and value is not None:
+                if SENSOR_TYPES[self._sensor][4] and value == 0:
+                    return
                 return round(value, 1)
 
         return value


### PR DESCRIPTION
Give the option to install the same station twice, supporting both the daily and the hourly forecast. Issue #53 
Also fixes issue #52 so that certain values are now not updated if the value we get from the API is 0. All the pressure values are included here.